### PR TITLE
Fix FF3_decrypt function

### DIFF
--- a/example.c
+++ b/example.c
@@ -43,12 +43,14 @@ int main(int argc, char *argv[])
 
     memset(resulttext, 0, txtlen);
     FPE_ff1_decrypt(ciphertext, resulttext, ff1);
+    printf("FF1 decrypted: %s\n\n", resulttext);
 
     FPE_ff3_encrypt(plaintext, ciphertext, ff3);
     printf("FF3 ciphertext: %s\n\n", ciphertext);
 
     memset(resulttext, 0, txtlen);
-    FPE_ff3_decrypt(ciphertext, plaintext, ff3);
+    FPE_ff3_decrypt(ciphertext, resulttext, ff3);
+    printf("FF3 decrypted: %s\n\n", resulttext);
 
     FPE_ff1_delete_key(ff1);
     FPE_ff3_delete_key(ff3);

--- a/src/ff3.c
+++ b/src/ff3.c
@@ -162,8 +162,8 @@ void FF3_decrypt(unsigned int *ciphertext, unsigned int *plaintext, FPE_KEY *key
     int v = txtlen - u;
 
     // Split the message
-    unsigned int *A = ciphertext;
-    unsigned int *B = ciphertext + u;
+    unsigned int *A = plaintext;
+    unsigned int *B = plaintext + u;
 
     pow_uv(qpow_u, qpow_v, key->radix, u, v, ctx);
     unsigned int temp = (unsigned int)ceil(u * log2(key->radix));


### PR DESCRIPTION
In FF3_decrypt function at 'Split the message' part, 'plaintext' must be assign to pointer named as 'A' and 'plaintext + u' must be assign to pointer named as 'B' for successful decryption.