### PR TITLE
Merge branch "feature.uppercase-alphabet" into "master"

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ void FPE_ff3_delete_key(FPE_KEY *keystruct);
 | ------- | ---------------------------------------- |
 | key | encryption key (128 bit, 192 bits or 256 bits), represented as a c string |
 | tweak   | tweak, represented as a c string (it must be 64 bytes) |
-| radix    | number of characters in the given alphabet, it must be in [2, 2^16] |
+| radix    | number of characters in the given alphabet, it must be in [2, 62] |
 | returns | FPE_KEY structure                        |
 
 4. encrypt or decrypt text using FF3 algorithm
@@ -115,7 +115,6 @@ void FPE_ff3_decrypt(char *ciphertext, char *plaintext, FPE_KEY *keystruct);
 | ----- | ---------------------------------------- |
 | plaintext  | numeral string to be encrypted, represented as an array of integers |
 | ciphertext | encrypted numeral string, represented as an array of integers |
-| radix | number of characters in the given alphabet, it must be in [2, 2^16] |
 | keystruct   | FPE_KEY structure that has been set with key and tweak |
 
 ## TODO

--- a/src/fpe_locl.c
+++ b/src/fpe_locl.c
@@ -60,6 +60,8 @@ void map_chars(char str[], unsigned int result[])
     for (int i = 0; i < len; ++i) {
         if (str[i] >= 'a')
             result[i] = str[i] - 'a' + 10;
+        else if (str[i] >= 'A')
+            result[i] = str[i] - 'A' + 36;
         else
             result[i] = str[i] - '0';
     }
@@ -70,8 +72,10 @@ void inverse_map_chars(unsigned int result[], char str[], int len)
     for (int i = 0; i < len; ++i) {
         if (result[i] < 10)
             str[i] = (result[i] + '0');
-        else 
+        else if (result[i] < 36)
             str[i] = result[i] - 10 + 'a';
+        else
+            str[i] = result[i] - 36 + 'A';
 	}
     str[len] = '\0';
 }

--- a/test.py
+++ b/test.py
@@ -250,10 +250,10 @@ testVectors_ACVP_AES_FF3_1 = [
 
 ]
 
-# Adapted from ACVP vectors for FF3-1 using 56-bit tweaks from private communication updating:
-# https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html#name-test-groups
+# Loosely adapted from ACVP vector test cases in mysto/python-fpe:
+# https://github.com/mysto/python-fpe/blob/main/ff3/ff3_test.py
 
-testVectors_ACVP_AES_FF3_1_radix_62 = [
+testVectors_radix_62 = [
     # AES - 128
     {
         "radix": 62,

--- a/test.py
+++ b/test.py
@@ -253,7 +253,7 @@ testVectors_ACVP_AES_FF3_1 = [
 # Loosely adapted from ACVP vector test cases in mysto/python-fpe:
 # https://github.com/mysto/python-fpe/blob/main/ff3/ff3_test.py
 
-testVectors_radix_62 = [
+testVectors_FF3_1_radix_62 = [
     # AES - 128
     {
         "radix": 62,
@@ -353,7 +353,7 @@ class TestFPE(unittest.TestCase):
 
     def xest_encrypt_acvp_radix_62(self):
         regexp = re.compile('(?<=ciphertext: )[a-zA-Z0-9]+')
-        for testVector in testVectors_radix_62:
+        for testVector in testVectors_FF3_1_radix_62:
             with self.subTest(testVector=testVector):
                 p = subprocess.Popen(['./example', testVector['key'], testVector['tweak'], str(testVector['radix']), testVector['plaintext']], stdin = subprocess.PIPE, stdout = subprocess.PIPE)
                 output = p.communicate()[0]

--- a/test.py
+++ b/test.py
@@ -353,7 +353,7 @@ class TestFPE(unittest.TestCase):
 
     def xest_encrypt_acvp_radix_62(self):
         regexp = re.compile('(?<=ciphertext: )[a-zA-Z0-9]+')
-        for testVector in testVectors_ACVP_AES_FF3_1_radix_62:
+        for testVector in testVectors_radix_62:
             with self.subTest(testVector=testVector):
                 p = subprocess.Popen(['./example', testVector['key'], testVector['tweak'], str(testVector['radix']), testVector['plaintext']], stdin = subprocess.PIPE, stdout = subprocess.PIPE)
                 output = p.communicate()[0]

--- a/test.py
+++ b/test.py
@@ -250,6 +250,57 @@ testVectors_ACVP_AES_FF3_1 = [
 
 ]
 
+# Adapted from ACVP vectors for FF3-1 using 56-bit tweaks from private communication updating:
+# https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html#name-test-groups
+
+testVectors_ACVP_AES_FF3_1_radix_62 = [
+    # AES - 128
+    {
+        "radix": 62,
+        "key": "AEE87D0D485B3AFD12BD1E0B9D03D50D",
+        "tweak": "5F9140601D224B",
+        "plaintext": "ixvuuIHr0e",
+        "ciphertext": "86gH2Pwy5y"
+    },
+    {
+        "radix": 62,
+        "key": "7B6C88324732F7F4AD435DA9AD77F917",
+        "tweak": "3F42102C0BAB39",
+        "plaintext": "21q1kbbIVSrAFtdFWzdMeIDpRqpo",
+        "ciphertext": "cJLGuBALkGa0AAhIMB6l3IXbjq9P"
+    },
+    # AES - 192
+    {
+        "radix": 62,
+        "key": "1C24B74B7C1B9969314CB53E92F98EFD620D5520017FB076",
+        "tweak": "0380341C425A6F",
+        "plaintext": "6np8r2t8zo",
+        "ciphertext": "LDB0GW0hFh"
+    },
+    {
+        "radix": 62,
+        "key": "C0ABADFC071379824A070E8C3FD40DD9BFD7A3C99A0D5FE3",
+        "tweak": "6C2926C705DDAF",
+        "plaintext": "GKB6sa9g56BSJ09iJ4dsaxRdsMvo",
+        "ciphertext": "eUJirBBwqIrxDXvPalKl8w8q1ajK"
+    },
+    # AES - 256
+    {
+        "radix": 62,
+        "key": "9C2B69F7DDF181C54398E345BE04C2F6B00B9DD1679200E1E04C4FF961AE0F09",
+        "tweak": "103C238B4B1E44",
+        "plaintext": "H2c6FblSA",
+        "ciphertext": "eV8s2hdAA"
+    },
+    {
+        "radix": 62,
+        "key": "C58BCBD08B90006CEC7E82B2D987D79F6A21111DEF0CEBB273CBAEB2D6CD4044",
+        "tweak": "7036604882667B",
+        "plaintext": "bz5TcS1krnD8IOLdrQeKzXkLAa6h",
+        "ciphertext": "UGuwjcZb32j8ev8R20rjtbEzrxSj"
+    }
+]
+
 class TestFPE(unittest.TestCase):
 
     def xest_vectors_ff1(self):
@@ -293,6 +344,16 @@ class TestFPE(unittest.TestCase):
     def xest_encrypt_acvp(self):
         regexp = re.compile('(?<=ciphertext: )[a-zA-Z0-9]+')
         for testVector in testVectors_ACVP_AES_FF3_1:
+            with self.subTest(testVector=testVector):
+                p = subprocess.Popen(['./example', testVector['key'], testVector['tweak'], str(testVector['radix']), testVector['plaintext']], stdin = subprocess.PIPE, stdout = subprocess.PIPE)
+                output = p.communicate()[0]
+                results = regexp.findall(output.decode('utf-8'))[1]
+                p.wait()
+                self.assertEqual(results, testVector['ciphertext'])
+
+    def xest_encrypt_acvp_radix_62(self):
+        regexp = re.compile('(?<=ciphertext: )[a-zA-Z0-9]+')
+        for testVector in testVectors_ACVP_AES_FF3_1_radix_62:
             with self.subTest(testVector=testVector):
                 p = subprocess.Popen(['./example', testVector['key'], testVector['tweak'], str(testVector['radix']), testVector['plaintext']], stdin = subprocess.PIPE, stdout = subprocess.PIPE)
                 output = p.communicate()[0]


### PR DESCRIPTION
Enabling the successful use of uppercase characters in encryption.

Previously, the alphabet was the following:
```
0123456789abcdefghijklmnopqrstuvwxyz
```

Now, the alphabet is the following:
```
0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ
```

Test vectors are derived from [mysto/python-fpe](https://github.com/mysto/python-fpe).